### PR TITLE
[Issue #7] 公式改进 V2 与 A/B 对照开关

### DIFF
--- a/issues/0024-formula-v2-and-ab-comparison.md
+++ b/issues/0024-formula-v2-and-ab-comparison.md
@@ -1,0 +1,38 @@
+# Issue #7 - SNN-SRA 公式改进 V2 与 A/B 对照验证
+
+GitHub Issue: https://github.com/unicorners-compin/snn-sra/issues/7
+
+## 背景
+
+当前增强版 SNN-SRA 公式包含较强工程经验项（线性加权、硬截断、硬最小值选路），在高压场景下可能出现饱和与抖动，限制性能上限。
+
+## 目标
+
+实现一版可运行的公式 V2，并保留 V1 兼容开关，完成最小 A/B 对照。
+
+## 方案范围
+
+1. 节点应力更新 V2
+   - 将 `kappa` 从硬截断改为平滑函数（sigmoid）
+2. 邻居评分 V2
+   - 对各项评分做归一化，减少量纲失衡
+3. 选路策略 V2
+   - 增加 softmin 温度采样选路（可关闭）
+4. 配置层
+   - 在 `main_snn.py` 增加 V2 运行模式入口（环境变量）
+5. 文档
+   - 新增 issue 与 PR 中文说明，记录公式变化与测试结论
+
+## 验收标准
+
+- 默认行为不变（V1 路径可用）
+- V2 可通过开关启用并成功运行
+- 主脚本 smoke 测试通过并产生结果文件
+- 代码含必要注释与文档，便于论文讨论
+
+## 输出物
+
+- `scripts_flow/snn_node.py`（V2 stress 选项）
+- `scripts_flow/snn_router.py`（归一化评分 + softmin 选项）
+- `scripts_flow/main_snn.py`（V2 模式入口）
+- `prs/0023-feature-formula-v2-and-ab-comparison.md`

--- a/prs/0023-feature-formula-v2-and-ab-comparison.md
+++ b/prs/0023-feature-formula-v2-and-ab-comparison.md
@@ -1,0 +1,41 @@
+# PR Draft: Feature Issue #7 - 公式改进 V2 与 A/B 对照开关
+
+## 关联 Issue
+
+- refs #7
+
+## Why
+
+当前公式存在硬截断与硬最小值决策，可能造成应力饱和和路径抖动。该 PR 引入可选的 V2 公式，并保留 V1 默认兼容。
+
+## 变更内容
+
+1. `scripts_flow/snn_node.py`
+   - 新增 `stress_mode` 机制：
+     - `v1`：原有 `kappa=min(1, raw)`
+     - `v2_sigmoid`：`kappa=sigmoid(gain*(raw-center))`
+2. `scripts_flow/snn_router.py`
+   - 新增评分归一化选项 `score_norm_mode=bounded`
+   - 新增 softmin 温度采样选路（`softmin_temperature>0`）
+   - 默认保持原先 hard-min 行为
+3. `scripts_flow/main_snn.py`
+   - 新增环境变量：
+     - `SNN_FORMULA_MODE` (`v1`/`v2`)
+     - `SNN_STEPS`
+     - `SNN_FAIL_STEP`
+   - 将 `formula_mode` 写入可视化元数据
+4. 新增 issue/PR 文档
+   - `issues/0024-formula-v2-and-ab-comparison.md`
+   - `prs/0023-feature-formula-v2-and-ab-comparison.md`
+
+## 验证命令
+
+```bash
+python3 -m py_compile scripts_flow/snn_node.py scripts_flow/snn_router.py scripts_flow/main_snn.py
+EXPERIMENT_RUN_DIR=run_dir/issue7_v1 SNN_NUM_NODES=25 SNN_TOPOLOGY=ba SNN_BA_M=2 SNN_ROUTING_MODE=snn_event_dv SNN_FORMULA_MODE=v1 SNN_STEPS=80 SNN_FAIL_STEP=40 python3 scripts_flow/main_snn.py
+EXPERIMENT_RUN_DIR=run_dir/issue7_v2 SNN_NUM_NODES=25 SNN_TOPOLOGY=ba SNN_BA_M=2 SNN_ROUTING_MODE=snn_event_dv SNN_FORMULA_MODE=v2 SNN_STEPS=80 SNN_FAIL_STEP=40 python3 scripts_flow/main_snn.py
+```
+
+## 备注
+
+- 本 PR 重点是“可切换公式框架”与最小 A/B 可运行性，不宣称已是最优参数。

--- a/scripts_flow/main_snn.py
+++ b/scripts_flow/main_snn.py
@@ -83,7 +83,7 @@ def choose_failure_edge(graph):
     return (int(edge[0]), int(edge[1]))
 
 
-def build_snn_runtime_config(topo_kind, routing_mode):
+def build_snn_runtime_config(topo_kind, routing_mode, formula_mode="v1"):
     router_kwargs = {
         "base_cost": 1.0,
         "beta_s": 8.0,
@@ -98,6 +98,8 @@ def build_snn_runtime_config(topo_kind, routing_mode):
         "syn_decay": 0.996,
         "syn_min": 0.0,
         "syn_max": 6.0,
+        "score_norm_mode": "none",
+        "softmin_temperature": 0.0,
     }
     sim_kwargs = {
         "hop_limit": 64,
@@ -155,6 +157,14 @@ def build_snn_runtime_config(topo_kind, routing_mode):
         # Disable burst related influence for DV-based control mode.
         router_kwargs["beta_burst"] = 0.0
 
+    if formula_mode == "v2":
+        router_kwargs.update(
+            {
+                "score_norm_mode": "bounded",
+                "softmin_temperature": 0.08,
+            }
+        )
+
     return {"router": router_kwargs, "sim": sim_kwargs}
 
 
@@ -171,6 +181,7 @@ def run_experiment(
     capture_viz=True,
     probe_flows=None,
     runtime_cfg=None,
+    formula_mode="v1",
 ):
     random.seed(seed)
     np.random.seed(seed)
@@ -187,6 +198,9 @@ def run_experiment(
             T_d=1,
             tau_m=4.0,
             v_th=1.0,
+            stress_mode="v2_sigmoid" if formula_mode == "v2" else "v1",
+            stress_smooth_gain=7.0,
+            stress_smooth_center=0.45,
         )
         for i in range(num_nodes)
     }
@@ -294,6 +308,9 @@ def main():
     ba_m = int(os.getenv("SNN_BA_M", "3"))
     layout_kind = os.getenv("SNN_LAYOUT", "spring")
     routing_mode = os.getenv("SNN_ROUTING_MODE", "snn_event_dv")
+    formula_mode = os.getenv("SNN_FORMULA_MODE", "v1").lower()
+    steps = int(os.getenv("SNN_STEPS", "300"))
+    fail_step = int(os.getenv("SNN_FAIL_STEP", "180"))
 
     base_graph = generate_topology(
         kind=topo_kind,
@@ -307,9 +324,9 @@ def main():
     failure_edge = choose_failure_edge(base_graph)
     print(
         f">>> [SNN] topology={topo_kind} nodes={base_graph.number_of_nodes()} "
-        f"edges={base_graph.number_of_edges()} failure_edge={failure_edge} mode={routing_mode}"
+        f"edges={base_graph.number_of_edges()} failure_edge={failure_edge} mode={routing_mode} formula={formula_mode}"
     )
-    runtime_cfg = build_snn_runtime_config(topo_kind, routing_mode)
+    runtime_cfg = build_snn_runtime_config(topo_kind, routing_mode, formula_mode=formula_mode)
 
     flow_cfg = build_flow_config(num_nodes=num_nodes, seed=topo_seed)
     probe_flows = [(f["src"], f["dst"]) for f in flow_cfg]
@@ -323,6 +340,9 @@ def main():
         capture_viz=True,
         probe_flows=probe_flows,
         runtime_cfg=runtime_cfg,
+        formula_mode=formula_mode,
+        steps=steps,
+        fail_step=fail_step,
     )
     snn_df, snn_viz = run_experiment(
         tag="snn_beta8",
@@ -334,6 +354,9 @@ def main():
         capture_viz=True,
         probe_flows=probe_flows,
         runtime_cfg=runtime_cfg,
+        formula_mode=formula_mode,
+        steps=steps,
+        fail_step=fail_step,
     )
     all_df = pd.concat([baseline_df, snn_df], ignore_index=True)
 
@@ -352,6 +375,7 @@ def main():
             "num_nodes": int(base_graph.number_of_nodes()),
             "num_edges": int(base_graph.number_of_edges()),
             "routing_mode": routing_mode,
+            "formula_mode": formula_mode,
         },
         "topology": build_topology_payload(base_graph, layout_positions, topo_kind),
         "scenarios": {

--- a/scripts_flow/snn_node.py
+++ b/scripts_flow/snn_node.py
@@ -1,4 +1,5 @@
 from collections import deque
+import math
 
 
 class SNNQueueNode:
@@ -20,6 +21,9 @@ class SNNQueueNode:
         spike_ema_decay=0.9,
         target_rate=0.08,
         homeostasis_lr=0.02,
+        stress_mode="v1",
+        stress_smooth_gain=6.0,
+        stress_smooth_center=0.5,
     ):
         self.node_id = node_id
         self.service_rate = service_rate
@@ -41,6 +45,9 @@ class SNNQueueNode:
         self.spike_ema_decay = spike_ema_decay
         self.target_rate = target_rate
         self.homeostasis_lr = homeostasis_lr
+        self.stress_mode = stress_mode
+        self.stress_smooth_gain = stress_smooth_gain
+        self.stress_smooth_center = stress_smooth_center
 
         self.v = v_reset
         self.refractory_left = 0
@@ -100,8 +107,12 @@ class SNNQueueNode:
         if step_k % self.T_d == 0:
             self.recent_loss_ratio = min(1.0, loss_intensity)
             self.last_queue_load = queue_load
-            # Couple spiking activity with queue/loss observables into structural stress.
-            kappa = min(1.0, 0.55 * self.spike_rate_ema + 0.25 * queue_load + 0.20 * self.recent_loss_ratio)
+            raw = 0.55 * self.spike_rate_ema + 0.25 * queue_load + 0.20 * self.recent_loss_ratio
+            if self.stress_mode == "v2_sigmoid":
+                z = self.stress_smooth_gain * (raw - self.stress_smooth_center)
+                kappa = 1.0 / (1.0 + math.exp(-z))
+            else:
+                kappa = min(1.0, raw)
             self.S = (1.0 - self.alpha) * self.S + self.alpha * kappa
             self.dropped_in_window = 0
 

--- a/scripts_flow/snn_router.py
+++ b/scripts_flow/snn_router.py
@@ -1,4 +1,6 @@
 import networkx as nx
+import math
+import random
 
 
 class SNNRouter:
@@ -19,6 +21,9 @@ class SNNRouter:
         syn_decay=0.995,
         syn_min=0.0,
         syn_max=8.0,
+        score_norm_mode="none",
+        softmin_temperature=0.0,
+        softmin_eps=1e-9,
     ):
         self.base_cost = base_cost
         self.beta_s = beta_s
@@ -33,6 +38,9 @@ class SNNRouter:
         self.syn_decay = syn_decay
         self.syn_min = syn_min
         self.syn_max = syn_max
+        self.score_norm_mode = score_norm_mode
+        self.softmin_temperature = softmin_temperature
+        self.softmin_eps = softmin_eps
 
         self.node_trace = {}
         self.syn_penalty = {}
@@ -104,6 +112,13 @@ class SNNRouter:
         link_cost = self.edge_cost(graph, nodes, curr, neighbor)
         spike_term = nodes[neighbor].spike_rate_ema
         h_term = self._hop_hint(graph, neighbor, dst)
+        if self.score_norm_mode == "bounded":
+            link_scale = max(1.0, self.base_cost + 2.0 * self.beta_s + self.syn_max)
+            link_cost = link_cost / link_scale
+            h_term = h_term / (h_term + 1.0)
+            spike_term = min(1.0, max(0.0, spike_term))
+            extra_penalty = min(1.0, max(0.0, float(extra_penalty)))
+            loop_penalty = 1.0 if loop_penalty > 0 else 0.0
         return (
             link_cost
             + self.beta_h * h_term
@@ -130,6 +145,7 @@ class SNNRouter:
 
         best_hop = None
         best_score = float("inf")
+        scored = []
 
         for v in neighbors:
             if avoid is not None and v == avoid:
@@ -146,8 +162,29 @@ class SNNRouter:
                 visited=visited,
                 extra_penalty=extra,
             )
+            scored.append((v, score))
             if score < best_score:
                 best_score = score
                 best_hop = v
+
+        if best_hop is None:
+            return (None, float("inf")) if return_score else None
+
+        if self.softmin_temperature > 0.0 and len(scored) > 1:
+            min_score = min(s for _, s in scored)
+            temp = max(self.softmin_temperature, self.softmin_eps)
+            weights = []
+            total_w = 0.0
+            for v, s in scored:
+                w = math.exp(-(s - min_score) / temp)
+                weights.append((v, s, w))
+                total_w += w
+            if total_w > 0:
+                r = random.random() * total_w
+                acc = 0.0
+                for v, s, w in weights:
+                    acc += w
+                    if r <= acc:
+                        return (v, s) if return_score else v
 
         return (best_hop, best_score) if return_score else best_hop


### PR DESCRIPTION
# PR Draft: Feature Issue #7 - 公式改进 V2 与 A/B 对照开关

## 关联 Issue

- refs #7

## Why

当前公式存在硬截断与硬最小值决策，可能造成应力饱和和路径抖动。该 PR 引入可选的 V2 公式，并保留 V1 默认兼容。

## 变更内容

1. `scripts_flow/snn_node.py`
   - 新增 `stress_mode` 机制：
     - `v1`：原有 `kappa=min(1, raw)`
     - `v2_sigmoid`：`kappa=sigmoid(gain*(raw-center))`
2. `scripts_flow/snn_router.py`
   - 新增评分归一化选项 `score_norm_mode=bounded`
   - 新增 softmin 温度采样选路（`softmin_temperature>0`）
   - 默认保持原先 hard-min 行为
3. `scripts_flow/main_snn.py`
   - 新增环境变量：
     - `SNN_FORMULA_MODE` (`v1`/`v2`)
     - `SNN_STEPS`
     - `SNN_FAIL_STEP`
   - 将 `formula_mode` 写入可视化元数据
4. 新增 issue/PR 文档
   - `issues/0024-formula-v2-and-ab-comparison.md`
   - `prs/0023-feature-formula-v2-and-ab-comparison.md`

## 验证命令

```bash
python3 -m py_compile scripts_flow/snn_node.py scripts_flow/snn_router.py scripts_flow/main_snn.py
EXPERIMENT_RUN_DIR=run_dir/issue7_v1 SNN_NUM_NODES=25 SNN_TOPOLOGY=ba SNN_BA_M=2 SNN_ROUTING_MODE=snn_event_dv SNN_FORMULA_MODE=v1 SNN_STEPS=80 SNN_FAIL_STEP=40 python3 scripts_flow/main_snn.py
EXPERIMENT_RUN_DIR=run_dir/issue7_v2 SNN_NUM_NODES=25 SNN_TOPOLOGY=ba SNN_BA_M=2 SNN_ROUTING_MODE=snn_event_dv SNN_FORMULA_MODE=v2 SNN_STEPS=80 SNN_FAIL_STEP=40 python3 scripts_flow/main_snn.py
```

## 备注

- 本 PR 重点是“可切换公式框架”与最小 A/B 可运行性，不宣称已是最优参数。
