### PR TITLE
[Issue #11] 实验路线图与 MinIO 归档规范

### DIFF
--- a/issues/0026-experiment-roadmap-and-minio-protocol.md
+++ b/issues/0026-experiment-roadmap-and-minio-protocol.md
@@ -1,0 +1,56 @@
+# Issue - 实验总路线图与 MinIO 归档协议（总控）
+
+## 背景
+
+为严格遵循 Git Flow 并保证实验可追溯，需要先建立统一路线图与数据归档协议。后续所有实验 issue 按本 issue 定义的顺序执行。
+
+## 目标
+
+1. 固化实验执行顺序（依赖关系）
+2. 固化 MinIO 上传命名规范、元数据规范、清理规范
+3. 作为后续实验 issue 的引用基准
+
+## 执行顺序（必须按序）
+
+1. V2 全矩阵统计主实验（v2 vs v1）
+2. 定向攻击与 k-failure 抗毁边界实验
+3. 故障恢复动力学实验（T50/T90/AUC）
+4. 节点失效与节点+链路混合失效实验
+5. 控制面退化鲁棒性实验（广播丢失/同步延迟）
+6. 参数敏感性与稳定区间实验
+7. V2 复杂度与收益-代价比复评估
+8. 终稿汇总实验（复现实验包）
+
+## MinIO 归档协议（后续每个 issue 必须执行）
+
+### 存储路径
+
+- Bucket: `snn-sra-exp`（如不存在可自动创建）
+- Prefix: `issue-<id>/<run_tag>/`
+
+### 必传文件
+
+1. 原始结果 CSV（runs/summary/significance）
+2. 运行日志（stdout/stderr）
+3. `metadata.json`，字段至少包括：
+   - `issue_id`
+   - `git_branch`
+   - `git_commit`
+   - `command`
+   - `start_time`
+   - `end_time`
+   - `host`
+   - `topos/sizes/seeds/steps/failure_profiles`
+   - `out_prefix`
+
+### 上传完成后的本地清理
+
+1. 先校验上传成功（对象存在）
+2. 执行本地删除（仅删除本次 run 生成文件）
+3. 在 PR 描述中写明“已上传 MinIO + 已清理本地”
+
+## 验收标准
+
+- 后续每个实验 issue 都显式引用本规范
+- 每个 issue 的结果都能在 MinIO 按 issue 号定位
+- 本地不会长期堆积大规模结果文件

--- a/issues/0027-v2-full-matrix-statistical-eval.md
+++ b/issues/0027-v2-full-matrix-statistical-eval.md
@@ -1,0 +1,35 @@
+# Issue - V2 全矩阵统计主实验（v2 vs v1）
+
+## 依赖
+
+- 依赖：实验总路线图与 MinIO 协议 issue
+
+## 目标
+
+在完整矩阵上比较 `formula_mode=v2` 与 `v1`，给出论文主结论级统计证据。
+
+## 实验矩阵
+
+- 拓扑：`ba, er`
+- 规模：`50, 100`
+- seeds：`1-20`
+- steps：`240`
+- fail-step：`150`
+- 故障：`single, frequent`
+- 路由模式：`snn_event_dv`（主）+ `snn_spike_native`（补）
+
+## 输出
+
+- `*_runs.csv`
+- `*_summary.csv`
+- `*_significance.csv`（v2-v1 差值、CI、p-value）
+
+## 核心指标
+
+- `pdr_final`, `loss_final`, `delay_final`, `hop_final`
+- `pdr_post`, `delay_post`
+
+## MinIO 与清理
+
+- 按总控 issue 的协议上传
+- 上传后删除本地 `run_dir` 结果副本

--- a/issues/0028-targeted-attack-and-kfailure-boundary.md
+++ b/issues/0028-targeted-attack-and-kfailure-boundary.md
@@ -1,0 +1,38 @@
+# Issue - 定向攻击与 k-failure 抗毁边界实验
+
+## 依赖
+
+- 依赖：V2 全矩阵统计主实验
+
+## 目标
+
+量化 SNN-SRA 在“抗毁性”核心问题上的边界：
+
+1. 随机故障 vs 定向攻击
+2. k-failure 递增下的崩溃阈值
+
+## 实验设计
+
+- 攻击策略：
+  - `random`
+  - `edge_betweenness_topk`
+  - `node_betweenness_topk`
+- `k` 从 1 递增到 K（按规模比例）
+- 记录每个 k 下指标曲线
+
+## 输出
+
+- `*_degradation_curve.csv`
+- `*_boundary.csv`（robust/weakened/failed）
+- `*_significance.csv`
+
+## 核心指标
+
+- PDR 退化幅度
+- Loss 增长幅度
+- 连通率（如可计算）
+- 崩溃阈值 \(k^\*\)
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理

--- a/issues/0029-recovery-dynamics-t50-t90-auc.md
+++ b/issues/0029-recovery-dynamics-t50-t90-auc.md
@@ -1,0 +1,31 @@
+# Issue - 故障恢复动力学实验（T50/T90/AUC）
+
+## 依赖
+
+- 依赖：定向攻击与 k-failure 抗毁边界实验
+
+## 目标
+
+把“抗毁性”从静态终值扩展到时序恢复能力，量化故障冲击后的恢复过程。
+
+## 指标定义
+
+- `MaxDrop`: 故障后最深退化
+- `T50`: 恢复到故障前 50% 水平所需步数
+- `T90`: 恢复到故障前 90% 水平所需步数
+- `AUC_recovery`: 故障后恢复曲线面积
+
+## 实验设置
+
+- 沿用主矩阵（ba/er, 50/100, seeds 1-20）
+- 对比：`v2`, `v1`, `ospf_sync`, `ecmp`, `ppo`
+
+## 输出
+
+- `*_recovery_runs.csv`
+- `*_recovery_summary.csv`
+- `*_recovery_significance.csv`
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理

--- a/issues/0030-node-and-hybrid-failure-resilience.md
+++ b/issues/0030-node-and-hybrid-failure-resilience.md
@@ -1,0 +1,32 @@
+# Issue - 节点失效与混合失效（节点+链路）抗毁实验
+
+## 依赖
+
+- 依赖：故障恢复动力学实验
+
+## 目标
+
+补齐当前以链路失效为主的空缺，验证 SNN-SRA 面对节点失效和混合失效时的稳健性。
+
+## 实验设计
+
+1. 仅节点失效（random / targeted）
+2. 节点+链路混合失效（交替或同时注入）
+3. 失效持续 vs 短时抖动（flap）
+
+## 输出
+
+- `*_node_failure_runs.csv`
+- `*_hybrid_failure_runs.csv`
+- `*_summary.csv`
+- `*_significance.csv`
+
+## 核心指标
+
+- `pdr_final/post`
+- `loss_final`
+- `recovery metrics`（T50/T90/AUC）
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理

--- a/issues/0031-control-plane-impaired-robustness.md
+++ b/issues/0031-control-plane-impaired-robustness.md
@@ -1,0 +1,27 @@
+# Issue - 控制面受限条件下的鲁棒性实验
+
+## 依赖
+
+- 依赖：节点失效与混合失效实验
+
+## 目标
+
+验证 SNN-SRA 不依赖理想控制面：在控制信息延迟、丢失和限频条件下仍保持核心优势。
+
+## 实验维度
+
+- 广播丢失率：0%, 5%, 10%, 20%
+- 广播延迟：0, 2, 5, 10 steps
+- 最小广播周期上调（限频）
+- 路由表 TTL 缩短/放宽
+
+## 输出
+
+- `*_cp_impaired_runs.csv`
+- `*_cp_impaired_summary.csv`
+- `*_cp_impaired_significance.csv`
+- `*_cp_boundary.csv`
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理

--- a/issues/0032-v2-parameter-sensitivity-and-stability.md
+++ b/issues/0032-v2-parameter-sensitivity-and-stability.md
@@ -1,0 +1,36 @@
+# Issue - V2 参数敏感性与稳定区间实验
+
+## 依赖
+
+- 依赖：控制面受限鲁棒性实验
+
+## 目标
+
+证明 V2 结论不是参数精调偶然，而是在合理参数扰动范围内稳定。
+
+## 参数网格
+
+- `stress_smooth_gain`
+- `stress_smooth_center`
+- `softmin_temperature`
+- `switch_hysteresis`
+- `route_ttl`
+
+每个参数做单因素扰动（建议 ±20%）并做关键参数二因素交叉抽样。
+
+## 输出
+
+- `*_sensitivity_runs.csv`
+- `*_sensitivity_summary.csv`
+- `*_sensitivity_significance.csv`
+- `*_stable_region.csv`（稳定区间）
+
+## 核心指标
+
+- 主收益：`pdr_final`, `loss_final`
+- 代价：`delay_final`, `hop_final`
+- 稳定性：`route_changes`, `table_updates`
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理

--- a/issues/0033-v2-overhead-and-final-repro-package.md
+++ b/issues/0033-v2-overhead-and-final-repro-package.md
@@ -1,0 +1,29 @@
+# Issue - V2 开销复评估与终稿复现实验包
+
+## 依赖
+
+- 依赖：V2 参数敏感性与稳定区间实验
+
+## 目标
+
+在 V2 最终配置下，完成“收益-代价”闭环和终稿可复现实验包。
+
+## 任务
+
+1. 复杂度与开销复评估（wall-clock / control msgs）
+2. 收益-代价比重算（对 OSPF/OSPF_SYNC/ECMP/PPO）
+3. 汇总最终结果包（论文图表所需 CSV）
+4. 产出 `REPRODUCE.md`（一键复现实验命令）
+
+## 输出
+
+- `*_overhead_runs.csv`
+- `*_overhead_summary.csv`
+- `*_benefit_cost.csv`
+- `*_final_bundle_manifest.json`
+- `run_dir/REPRODUCE.md`
+
+## MinIO 与清理
+
+- 按总控 issue 协议上传和清理
+- 清理后保留最小索引文件（manifest + reproduce 文档）

--- a/prs/0025-plan-experiment-roadmap-and-minio.md
+++ b/prs/0025-plan-experiment-roadmap-and-minio.md
@@ -1,0 +1,37 @@
+# PR Draft: Plan Issue #11 - 实验路线图与 MinIO 归档规范
+
+## 关联 Issue
+
+- refs #11
+
+## Why
+
+将后续实验从“临时执行”升级为“可追踪计划驱动”，并统一 MinIO 上传与本地清理规范，确保每个实验结果可复现、可检索。
+
+## 本 PR 内容
+
+- 新增实验计划 issue 文档：
+  - `issues/0026-experiment-roadmap-and-minio-protocol.md`
+  - `issues/0027-v2-full-matrix-statistical-eval.md`
+  - `issues/0028-targeted-attack-and-kfailure-boundary.md`
+  - `issues/0029-recovery-dynamics-t50-t90-auc.md`
+  - `issues/0030-node-and-hybrid-failure-resilience.md`
+  - `issues/0031-control-plane-impaired-robustness.md`
+  - `issues/0032-v2-parameter-sensitivity-and-stability.md`
+  - `issues/0033-v2-overhead-and-final-repro-package.md`
+
+## GitHub Issues（已创建）
+
+- #11 实验总路线图与 MinIO 归档协议（总控）
+- #12 V2 全矩阵统计主实验（v2 vs v1）
+- #13 定向攻击与 k-failure 抗毁边界实验
+- #14 故障恢复动力学实验（T50/T90/AUC）
+- #15 节点失效与混合失效（节点+链路）抗毁实验
+- #16 控制面受限条件下的鲁棒性实验
+- #17 V2 参数敏感性与稳定区间实验
+- #18 V2 开销复评估与终稿复现实验包
+
+## 备注
+
+- 本 PR 是计划与规范，不包含实验结果。
+- issue #12~#18 将按顺序逐个执行，每次完成后上传 MinIO 并清理本地结果。


### PR DESCRIPTION
# PR Draft: Plan Issue #11 - 实验路线图与 MinIO 归档规范

## 关联 Issue

- refs #11

## Why

将后续实验从“临时执行”升级为“可追踪计划驱动”，并统一 MinIO 上传与本地清理规范，确保每个实验结果可复现、可检索。

## 本 PR 内容

- 新增实验计划 issue 文档：
  - `issues/0026-experiment-roadmap-and-minio-protocol.md`
  - `issues/0027-v2-full-matrix-statistical-eval.md`
  - `issues/0028-targeted-attack-and-kfailure-boundary.md`
  - `issues/0029-recovery-dynamics-t50-t90-auc.md`
  - `issues/0030-node-and-hybrid-failure-resilience.md`
  - `issues/0031-control-plane-impaired-robustness.md`
  - `issues/0032-v2-parameter-sensitivity-and-stability.md`
  - `issues/0033-v2-overhead-and-final-repro-package.md`

## GitHub Issues（已创建）

- #11 实验总路线图与 MinIO 归档协议（总控）
- #12 V2 全矩阵统计主实验（v2 vs v1）
- #13 定向攻击与 k-failure 抗毁边界实验
- #14 故障恢复动力学实验（T50/T90/AUC）
- #15 节点失效与混合失效（节点+链路）抗毁实验
- #16 控制面受限条件下的鲁棒性实验
- #17 V2 参数敏感性与稳定区间实验
- #18 V2 开销复评估与终稿复现实验包

## 备注

- 本 PR 是计划与规范，不包含实验结果。
- issue #12~#18 将按顺序逐个执行，每次完成后上传 MinIO 并清理本地结果。
