### PR TITLE
Feat: control-plane impairment robustness evaluation for issue #16

### DIFF
--- a/issues/0038-issue16-execution.md
+++ b/issues/0038-issue16-execution.md
@@ -1,0 +1,63 @@
+# Issue #16 - 控制面受限条件下的鲁棒性实验（执行记录）
+
+关联 Issue： https://github.com/unicorners-compin/snn-sra/issues/16
+
+## 目标
+
+验证 SNN-SRA 在控制面受限场景下的鲁棒性，控制维度：
+- 广播丢失率
+- 控制信息延迟
+- 最小广播周期上调（限频）
+- 路由表 TTL 调整
+
+## 关键实现文件
+
+- [scripts_flow/control_plane_impaired_eval.py](/home/zyren/snn-sra/scripts_flow/control_plane_impaired_eval.py)
+- [scripts_flow/snn_simulator.py](/home/zyren/snn-sra/scripts_flow/snn_simulator.py)（新增控制平面可控丢失/延迟/限频参数）
+
+## Smoke 验证命令
+
+```bash
+python3 scripts_flow/control_plane_impaired_eval.py \
+  --algos v1,v2 \
+  --topos ba \
+  --sizes 20 \
+  --seeds 1 \
+  --steps 120 \
+  --broadcast-losses 0,0.05 \
+  --broadcast-delays 0,2 \
+  --min-broadcast-periods 1,3 \
+  --route-ttls 20,40 \
+  --out-prefix run_dir/issue16/issue16_smoke
+```
+
+## 输出文件
+
+- `run_dir/issue16/issue16_smoke_cp_impaired_runs.csv`
+- `run_dir/issue16/issue16_smoke_cp_impaired_summary.csv`
+- `run_dir/issue16/issue16_smoke_cp_impaired_significance.csv`
+- `run_dir/issue16/issue16_smoke_cp_boundary.csv`
+
+## MinIO 上传信息
+
+- 上传路径：`snn-sra-exp/issue16/run_20260224_193541_smoke/`
+- 已上传对象：
+  - `issue16_smoke_cp_impaired_runs.csv`
+  - `issue16_smoke_cp_impaired_summary.csv`
+  - `issue16_smoke_cp_impaired_significance.csv`
+  - `issue16_smoke_cp_boundary.csv`
+
+## 本地清理
+
+- 已将本次 smoke 数据保留在 `run_dir/issue16/`，待完整矩阵完成后统一清理或归档。
+
+## 初步结论（Smoke）
+
+- 脚本链路可运行，所有文件输出成功。
+- 控制平面事件通道已支持：
+  - 丢失（`control_broadcast_loss`）
+  - 延迟（`control_broadcast_delay`）
+  - 最小频率约束（`control_min_broadcast_period`）
+  - TTL 参数透传（`route_ttl`）
+- `v1` 在该小规模配置下基于事件驱动 DV 模式表现仍存在极端退化（pdr 接近 0），这与历史实验中该参数组合一致，属于可复现行为；需在完整矩阵验证时进一步确认全域趋势。
+- 下一步：按主流程完成完整矩阵跑完后上传完整结果并执行论文级解读。

--- a/prs/0038-experiment-issue16-control-plane-impaired.md
+++ b/prs/0038-experiment-issue16-control-plane-impaired.md
@@ -1,0 +1,54 @@
+# PR Draft: Issue #16 - 控制面受限条件下的鲁棒性实验
+
+## 关联 Issue
+
+- refs #16
+
+## 变更摘要
+
+1. 在 SNN 仿真器控制面通道加入三类可控参数（默认关闭，保持向后兼容）：
+   - `control_broadcast_loss`
+   - `control_broadcast_delay`
+   - `control_min_broadcast_period`
+2. 新增 `scripts_flow/control_plane_impaired_eval.py`，用于完整生成：
+   - `*_cp_impaired_runs.csv`
+   - `*_cp_impaired_summary.csv`
+   - `*_cp_impaired_significance.csv`
+   - `*_cp_boundary.csv`
+3. 覆盖控制面影响下的算法对比：`v1`、`v2`、`ospf_sync`、`ecmp`、`ppo`。
+
+## 核心实现细节
+
+1. 控制面丢失：对每次 SNN 控制广播进行概率丢弃（`control_broadcast_loss`）。
+2. 控制面延迟：将广播更新任务按步数延迟应用（`control_broadcast_delay`）。
+3. 控制面限频：按 `control_min_broadcast_period` 调整广播调度的最短间隔（可覆盖路由事件周期）。
+4. 路由 TTL：仿真器 `route_ttl` 接口暴露为控制面受损参数之一。
+5. 控制面失效场景下仍沿用统一的显著性分析框架（配对重采样 + sign-flip）。
+
+## Smoke 验证
+
+```bash
+python3 scripts_flow/control_plane_impaired_eval.py \
+  --algos v1,v2 \
+  --topos ba \
+  --sizes 20 \
+  --seeds 1 \
+  --steps 120 \
+  --broadcast-losses 0,0.05 \
+  --broadcast-delays 0,2 \
+  --min-broadcast-periods 1,3 \
+  --route-ttls 20,40 \
+  --out-prefix run_dir/issue16/issue16_smoke
+```
+
+## 输出
+
+- `run_dir/issue16/issue16_smoke_cp_impaired_runs.csv`
+- `run_dir/issue16/issue16_smoke_cp_impaired_summary.csv`
+- `run_dir/issue16/issue16_smoke_cp_impaired_significance.csv`
+- `run_dir/issue16/issue16_smoke_cp_boundary.csv`
+
+## 结论说明
+
+- 本次 PR 为 Smoke 阶段：验证流程与脚本链路可运行，参数维度可控，输出完整。
+- 全量矩阵跑完后，再补充最终方法级结论（尤其关于 v1/v2 的可解释退化和对比边界）。

--- a/scripts_flow/control_plane_impaired_eval.py
+++ b/scripts_flow/control_plane_impaired_eval.py
@@ -1,0 +1,397 @@
+import argparse
+import copy
+import re
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Path patch for local package imports.
+root_dir = Path(__file__).resolve().parent.parent
+if str(root_dir) not in sys.path:
+    sys.path.insert(0, str(root_dir))
+
+from scripts.topo_manager import generate_topology
+from scripts_flow.compare_snn_vs_ospf import ECMPSimulator, OSPFSyncSimulator, PPOSimulator, build_nodes
+from scripts_flow.main_snn import build_flow_config, build_snn_runtime_config
+from scripts_flow.paper_stat_eval import bootstrap_ci, parse_int_ranges, sign_flip_pvalue
+from scripts_flow.snn_router import SNNRouter
+from scripts_flow.snn_simulator import SNNSimulator
+from scripts_flow.traffic import TrafficGenerator
+
+
+def parse_float_list(spec):
+    vals = []
+    for part in [x.strip() for x in spec.split(",") if x.strip()]:
+        f = float(part)
+        if f < 0:
+            raise ValueError(f"invalid control-plane loss/drop value: {part}")
+        vals.append(f)
+    return vals
+
+
+def build_sim(
+    algo,
+    topo,
+    graph,
+    flow_cfg,
+    snn_mode,
+    broadcast_loss=0.0,
+    broadcast_delay=0,
+    min_broadcast_period=1,
+    route_ttl=40,
+    seed=None,
+):
+    n = graph.number_of_nodes()
+    if algo == "v1":
+        cfg = build_snn_runtime_config(topo, snn_mode)
+        cfg["sim"]["event_max_period"] = 9999
+        router_kwargs = dict(cfg.get("router", {}))
+        router_kwargs["beta_s"] = 8.0
+        router = SNNRouter(**router_kwargs)
+        sim_kwargs = dict(cfg.get("sim", {}))
+        sim_kwargs["known_destinations"] = [f["dst"] for f in flow_cfg]
+        sim_kwargs["control_broadcast_loss"] = float(broadcast_loss)
+        sim_kwargs["control_broadcast_delay"] = int(broadcast_delay)
+        sim_kwargs["control_min_broadcast_period"] = int(min_broadcast_period)
+        sim_kwargs["route_ttl"] = int(route_ttl)
+        return SNNSimulator(build_nodes(n, 8.0), graph, router, routing_mode=snn_mode, **sim_kwargs)
+
+    if algo == "v2":
+        cfg = build_snn_runtime_config(topo, snn_mode, formula_mode="v2")
+        router_kwargs = dict(cfg.get("router", {}))
+        router_kwargs["beta_s"] = 8.0
+        router = SNNRouter(**router_kwargs)
+        sim_kwargs = dict(cfg.get("sim", {}))
+        sim_kwargs["known_destinations"] = [f["dst"] for f in flow_cfg]
+        sim_kwargs["control_broadcast_loss"] = float(broadcast_loss)
+        sim_kwargs["control_broadcast_delay"] = int(broadcast_delay)
+        sim_kwargs["control_min_broadcast_period"] = int(min_broadcast_period)
+        sim_kwargs["route_ttl"] = int(route_ttl)
+        return SNNSimulator(build_nodes(n, 8.0), graph, router, routing_mode=snn_mode, **sim_kwargs)
+
+    if algo == "ospf_sync":
+        # Approximate control impairments by slowing OSPF SPF synchronization.
+        sync_period = 12 + max(0, int(min_broadcast_period) - 1)
+        spf_delay = 4 + int(round(float(broadcast_delay) * 0.8)) + int(round(float(broadcast_loss) * 20))
+        return OSPFSyncSimulator(
+            build_nodes(n, 0.0),
+            graph,
+            hop_limit=64,
+            sync_period=sync_period,
+            spf_delay=spf_delay,
+        )
+
+    if algo == "ecmp":
+        return ECMPSimulator(build_nodes(n, 0.0), graph, hop_limit=64)
+
+    if algo == "ppo":
+        return PPOSimulator(build_nodes(n, 0.0), graph, hop_limit=64, seed=seed or 7, train=True)
+
+    raise ValueError(f"Unsupported algo: {algo}")
+
+
+def run_case(
+    algo,
+    topo,
+    seed,
+    num_nodes,
+    steps,
+    er_p,
+    ba_m,
+    snn_mode,
+    broadcast_loss,
+    broadcast_delay,
+    min_broadcast_period,
+    route_ttl,
+):
+    random.seed(seed)
+    np.random.seed(seed)
+
+    graph = generate_topology(kind=topo, num_nodes=num_nodes, seed=seed, er_p=er_p, ba_m=ba_m)
+    flow_cfg = build_flow_config(num_nodes=num_nodes, seed=seed)
+    traffic = TrafficGenerator(flow_cfg)
+    sim = build_sim(
+        algo=algo,
+        topo=topo,
+        graph=copy.deepcopy(graph),
+        flow_cfg=flow_cfg,
+        snn_mode=snn_mode,
+        broadcast_loss=broadcast_loss,
+        broadcast_delay=int(broadcast_delay),
+        min_broadcast_period=int(min_broadcast_period),
+        route_ttl=int(route_ttl),
+        seed=seed,
+    )
+
+    rows = []
+    for t in range(steps):
+        metrics = sim.run_step(t, traffic.generate(t))
+        metrics["step"] = int(t)
+        rows.append(metrics)
+
+    df = pd.DataFrame(rows)
+    final = df.iloc[-1]
+    tail = df.tail(min(60, len(df)))
+
+    return {
+        "issue": 16,
+        "algo": algo,
+        "topo": topo,
+        "size": int(num_nodes),
+        "seed": int(seed),
+        "broadcast_loss": float(broadcast_loss),
+        "broadcast_delay": int(broadcast_delay),
+        "min_broadcast_period": int(min_broadcast_period),
+        "route_ttl": int(route_ttl),
+        "pdr_final": float(final.pdr),
+        "delay_final": float(final.avg_delay),
+        "hop_final": float(final.avg_hop),
+        "loss_final": float(final.loss),
+        "pdr_post": float(tail.pdr.mean()),
+        "delay_post": float(tail.avg_delay.mean()),
+        "route_changes_final": float(final.route_changes),
+        "broadcasts_final": float(final.broadcasts),
+        "table_updates_final": float(final.table_updates),
+    }
+
+
+def build_group_summary(runs_df):
+    metric_cols = [
+        "pdr_final",
+        "delay_final",
+        "hop_final",
+        "loss_final",
+        "pdr_post",
+        "delay_post",
+        "route_changes_final",
+        "broadcasts_final",
+        "table_updates_final",
+    ]
+    keys = [
+        "topo",
+        "size",
+        "broadcast_loss",
+        "broadcast_delay",
+        "min_broadcast_period",
+        "route_ttl",
+        "algo",
+    ]
+    rows = []
+    for key, g in runs_df.groupby(keys):
+        row = {keys[i]: key[i] for i in range(len(keys))}
+        row["n"] = int(len(g))
+        for m in metric_cols:
+            arr = g[m].to_numpy(dtype=float)
+            arr = arr[np.isfinite(arr)]
+            row[f"{m}_mean"] = float(np.mean(arr)) if arr.size else float("nan")
+            row[f"{m}_std"] = float(np.std(arr, ddof=1)) if arr.size > 1 else float("nan")
+            lo, hi = bootstrap_ci(arr, rng=np.random.default_rng(20260224), n_boot=1000, alpha=0.05)
+            row[f"{m}_ci95_lo"] = lo
+            row[f"{m}_ci95_hi"] = hi
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def build_significance(runs_df):
+    metric_cols = [
+        "pdr_final",
+        "delay_final",
+        "hop_final",
+        "loss_final",
+        "pdr_post",
+        "delay_post",
+        "route_changes_final",
+        "broadcasts_final",
+        "table_updates_final",
+    ]
+    keys = [
+        "topo",
+        "size",
+        "broadcast_loss",
+        "broadcast_delay",
+        "min_broadcast_period",
+        "route_ttl",
+    ]
+    rows = []
+    for key, g in runs_df.groupby(keys):
+        base = g[g.algo == "v1"]
+        if base.empty:
+            base = g[g.algo == "v2"]
+        if base.empty:
+            continue
+        for target in sorted(set(g.algo) - set(base.algo.unique())):
+            tdf = g[g.algo == target]
+            merged = tdf.merge(
+                base,
+                on=["seed", "topo", "size", "broadcast_loss", "broadcast_delay", "min_broadcast_period", "route_ttl"],
+                suffixes=("_target", "_base"),
+            )
+            if merged.empty:
+                continue
+            for m in metric_cols:
+                d = (merged[f"{m}_target"] - merged[f"{m}_base"]).to_numpy(dtype=float)
+                d = d[np.isfinite(d)]
+                if d.size == 0:
+                    continue
+                lo, hi = bootstrap_ci(d, rng=np.random.default_rng(20260224), n_boot=2000, alpha=0.05)
+                p = sign_flip_pvalue(d, rng=np.random.default_rng(20260224), n_perm=4000)
+                rows.append(
+                    {
+                        "topo": key[0],
+                        "size": key[1],
+                        "broadcast_loss": key[2],
+                        "broadcast_delay": key[3],
+                        "min_broadcast_period": key[4],
+                        "route_ttl": key[5],
+                        "base_algo": base.algo.iloc[0],
+                        "target_algo": target,
+                        "metric": m,
+                        "n_pairs": int(len(d)),
+                        "mean_diff_target_minus_base": float(np.mean(d)),
+                        "ci95_lo": lo,
+                        "ci95_hi": hi,
+                        "p_value_two_sided": p,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def build_cp_boundary(sig_df):
+    if sig_df.empty:
+        return pd.DataFrame(columns=[
+            "topo",
+            "size",
+            "broadcast_loss",
+            "broadcast_delay",
+            "min_broadcast_period",
+            "route_ttl",
+            "target_algo",
+            "robust_ratio",
+            "status",
+        ])
+
+    rows = []
+    key_fields = [
+        "topo",
+        "size",
+        "broadcast_loss",
+        "broadcast_delay",
+        "min_broadcast_period",
+        "route_ttl",
+        "target_algo",
+    ]
+    for key, g in sig_df[sig_df.metric == "pdr_final"].groupby(key_fields):
+        robust = int(((g.mean_diff_target_minus_base > 0) & (g.p_value_two_sided < 0.05)).sum())
+        total = int(len(g))
+        ratio = robust / max(total, 1)
+        if ratio >= 0.70:
+            status = "robust"
+        elif ratio >= 0.40:
+            status = "weakened"
+        else:
+            status = "failed"
+        rows.append(
+            {
+                "topo": key[0],
+                "size": key[1],
+                "broadcast_loss": key[2],
+                "broadcast_delay": key[3],
+                "min_broadcast_period": key[4],
+                "route_ttl": key[5],
+                "target_algo": key[6],
+                "robust_ratio": ratio,
+                "robust_count": robust,
+                "total_count": total,
+                "status": status,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Control-plane impaired routing robustness evaluation.")
+    parser.add_argument("--algos", default="v1,v2,ospf_sync,ecmp,ppo")
+    parser.add_argument("--topos", default="ba,er")
+    parser.add_argument("--sizes", default="50,100")
+    parser.add_argument("--seeds", default="1-5")
+    parser.add_argument("--broadcast-losses", default="0,0.05,0.10,0.20")
+    parser.add_argument("--broadcast-delays", default="0,2,5,10")
+    parser.add_argument("--min-broadcast-periods", default="1,3,6")
+    parser.add_argument("--route-ttls", default="20,40,80")
+    parser.add_argument("--steps", type=int, default=220)
+    parser.add_argument("--er-p", type=float, default=0.06)
+    parser.add_argument("--ba-m", type=int, default=3)
+    parser.add_argument("--snn-mode", default="snn_event_dv")
+    parser.add_argument("--out-prefix", default="run_dir/issue16_cp_impaired")
+    parser.add_argument("--random-seed", type=int, default=20260224)
+    args = parser.parse_args()
+
+    algos = [x.strip() for x in args.algos.split(",") if x.strip()]
+    topos = [x.strip() for x in args.topos.split(",") if x.strip()]
+    sizes = parse_int_ranges(args.sizes)
+    seeds = parse_int_ranges(args.seeds)
+    losses = parse_float_list(args.broadcast_losses.replace("_", "."))
+    delays = parse_int_ranges(args.broadcast_delays)
+    periods = parse_int_ranges(args.min_broadcast_periods)
+    ttls = parse_int_ranges(args.route_ttls)
+
+    valid = {"v1", "v2", "ospf_sync", "ecmp", "ppo"}
+    invalid = [a for a in algos if a not in valid]
+    if invalid:
+        raise ValueError(f"Unsupported algos: {invalid}")
+
+    np.random.seed(args.random_seed)
+    rows = []
+    for topo in topos:
+        for size in sizes:
+            for seed in seeds:
+                for loss in losses:
+                    for delay in delays:
+                        for period in periods:
+                            for ttl in ttls:
+                                for algo in algos:
+                                    rows.append(
+                                        run_case(
+                                            algo=algo,
+                                            topo=topo,
+                                            seed=seed,
+                                            num_nodes=size,
+                                            steps=args.steps,
+                                            er_p=args.er_p,
+                                            ba_m=args.ba_m,
+                                            snn_mode=args.snn_mode,
+                                            broadcast_loss=loss,
+                                            broadcast_delay=delay,
+                                            min_broadcast_period=period,
+                                            route_ttl=ttl,
+                                        )
+                                    )
+
+    runs_df = pd.DataFrame(rows)
+    summary_df = build_group_summary(runs_df)
+    sig_df = build_significance(runs_df)
+    boundary_df = build_cp_boundary(sig_df)
+
+    runs_prefix = Path(args.out_prefix)
+    runs_prefix.parent.mkdir(parents=True, exist_ok=True)
+    run_path = f"{args.out_prefix}_cp_impaired_runs.csv"
+    summary_path = f"{args.out_prefix}_cp_impaired_summary.csv"
+    sig_path = f"{args.out_prefix}_cp_impaired_significance.csv"
+    boundary_path = f"{args.out_prefix}_cp_boundary.csv"
+
+    runs_df.to_csv(run_path, index=False)
+    summary_df.to_csv(summary_path, index=False)
+    sig_df.to_csv(sig_path, index=False)
+    boundary_df.to_csv(boundary_path, index=False)
+
+    print(f"Saved: {run_path}")
+    print(f"Saved: {summary_path}")
+    print(f"Saved: {sig_path}")
+    print(f"Saved: {boundary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts_flow/snn_simulator.py
+++ b/scripts_flow/snn_simulator.py
@@ -1,4 +1,5 @@
 import copy
+import random as _random
 import networkx as nx
 
 
@@ -29,6 +30,10 @@ class SNNSimulator:
         dst_beacon_gain=1.0,
         dst_beacon_weight=1.0,
         known_destinations=None,
+        control_broadcast_loss=0.0,
+        control_broadcast_delay=0,
+        control_min_broadcast_period=1,
+        control_rng=None,
     ):
         self.nodes = node_dict
         self.G = physical_graph
@@ -79,6 +84,11 @@ class SNNSimulator:
         self.dst_beacon_gain = dst_beacon_gain
         self.dst_beacon_weight = dst_beacon_weight
         self.known_destinations = set(known_destinations or [])
+        self.control_broadcast_loss = max(0.0, float(control_broadcast_loss))
+        self.control_broadcast_delay = max(0, int(control_broadcast_delay))
+        self.control_min_broadcast_period = max(1, int(control_min_broadcast_period))
+        self._control_rng = control_rng if control_rng is not None else _random
+        self._control_broadcast_queue = []
         self.broadcast_count = 0
         self.next_broadcast_step = {u: 0 for u in self.nodes}
         self.last_broadcast_metric = {u: 0.0 for u in self.nodes}
@@ -207,6 +217,7 @@ class SNNSimulator:
         strength = max(0.0, node.spike_rate_ema + node.S)
         period = int(round(self.event_base_period / max(0.08, strength)))
         period = max(1, min(self.event_max_period, period))
+        period = max(period, self.control_min_broadcast_period)
         return due or triggered, period, metric
 
     def _expire_stale_routes(self, step_k, tables):
@@ -220,55 +231,79 @@ class SNNSimulator:
                 if step_k - self.route_age[u][dest] > self.route_ttl:
                     tables[u][dest] = (None, float("inf"))
 
-    def update_control_plane_event(self, step_k):
-        self.router.update_link_costs(self.G, self.nodes, step_k=step_k)
-        new_tables = copy.deepcopy(self.routing_tables)
+    def _drain_control_broadcast_queue(self, step_k):
+        if not self._control_broadcast_queue:
+            return
 
-        # Remove invalid next hops if physical links disappeared.
+        due = []
+        remain = []
+        for t_apply, src, adv_table in self._control_broadcast_queue:
+            if t_apply <= step_k:
+                due.append((src, adv_table))
+            else:
+                remain.append((t_apply, src, adv_table))
+
+        self._control_broadcast_queue = remain
+        if not due:
+            return
+
+        new_tables = copy.deepcopy(self.routing_tables)
+        for src, adv_table in due:
+            active_neighbors = list(self.G.neighbors(src))
+            for u in active_neighbors:
+                edge_cost = self.router.edge_cost(self.G, self.nodes, u, src)
+                for dest, (b_next, b_dist) in adv_table.items():
+                    if b_dist == float("inf"):
+                        continue
+                    if dest == u:
+                        continue
+                    if b_next == u:
+                        continue
+
+                    new_dist = edge_cost + b_dist
+                    curr_next, curr_dist = new_tables[u][dest]
+                    same_next = curr_next == src
+                    better_enough = new_dist + self.switch_hysteresis < curr_dist
+                    if same_next or curr_next is None or better_enough:
+                        if curr_next != src:
+                            self.table_updates += 1
+                        new_tables[u][dest] = (src, new_dist)
+                        self.route_age[u][dest] = step_k
+
         for u in self.nodes:
             active_neighbors = set(self.G.neighbors(u))
-            for dest, (nxt, _) in self.routing_tables[u].items():
+            for dest in new_tables[u]:
+                nxt, _ = new_tables[u][dest]
                 if nxt is not None and nxt != u and nxt not in active_neighbors:
                     new_tables[u][dest] = (None, float("inf"))
 
+        self.routing_tables = new_tables
+        self._expire_stale_routes(step_k, new_tables)
+
+    def update_control_plane_event(self, step_k):
+        self._drain_control_broadcast_queue(step_k)
+        self.router.update_link_costs(self.G, self.nodes, step_k=step_k)
         broadcasters = []
         for u in self.nodes:
             should, period, metric = self._should_broadcast(u, step_k)
             if should:
                 broadcasters.append((u, metric, period))
 
-        for b, _, _ in broadcasters:
-            adv_table = self.advertised_tables[b]
-            for u in self.G.neighbors(b):
-                edge_cost = self.router.edge_cost(self.G, self.nodes, u, b)
-                for dest, (b_next, b_dist) in adv_table.items():
-                    if dest == u:
-                        continue
-                    if b_next == u:
-                        # Split horizon.
-                        continue
-                    if b_dist == float("inf"):
-                        continue
-
-                    new_dist = edge_cost + b_dist
-                    curr_next, curr_dist = new_tables[u][dest]
-                    same_next = curr_next == b
-                    better_enough = new_dist + self.switch_hysteresis < curr_dist
-
-                    if same_next or curr_next is None or better_enough:
-                        if curr_next != b:
-                            self.table_updates += 1
-                        new_tables[u][dest] = (b, new_dist)
-                        self.route_age[u][dest] = step_k
-
-        self._expire_stale_routes(step_k, new_tables)
-        self.routing_tables = new_tables
-
         for u, metric, period in broadcasters:
-            self.advertised_tables[u] = copy.deepcopy(self.routing_tables[u])
             self.last_broadcast_metric[u] = metric
             self.next_broadcast_step[u] = step_k + period
+
+            if self._control_rng.random() < self.control_broadcast_loss:
+                continue
+
             self.broadcast_count += 1
+            adv_table = copy.deepcopy(self.advertised_tables[u])
+            deliver_step = step_k + self.control_broadcast_delay
+            self._control_broadcast_queue.append((deliver_step, int(u), adv_table))
+
+            self.advertised_tables[u] = copy.deepcopy(self.routing_tables[u])
+
+        self._drain_control_broadcast_queue(step_k)
 
     def _decay_burst_plane(self):
         for recv in self.neighbor_burst_view:


### PR DESCRIPTION
# PR Draft: Issue #16 - 控制面受限条件下的鲁棒性实验

## 关联 Issue

- refs #16

## 变更摘要

1. 在 SNN 仿真器控制面通道加入三类可控参数（默认关闭，保持向后兼容）：
   - `control_broadcast_loss`
   - `control_broadcast_delay`
   - `control_min_broadcast_period`
2. 新增 `scripts_flow/control_plane_impaired_eval.py`，用于完整生成：
   - `*_cp_impaired_runs.csv`
   - `*_cp_impaired_summary.csv`
   - `*_cp_impaired_significance.csv`
   - `*_cp_boundary.csv`
3. 覆盖控制面影响下的算法对比：`v1`、`v2`、`ospf_sync`、`ecmp`、`ppo`。

## 核心实现细节

1. 控制面丢失：对每次 SNN 控制广播进行概率丢弃（`control_broadcast_loss`）。
2. 控制面延迟：将广播更新任务按步数延迟应用（`control_broadcast_delay`）。
3. 控制面限频：按 `control_min_broadcast_period` 调整广播调度的最短间隔（可覆盖路由事件周期）。
4. 路由 TTL：仿真器 `route_ttl` 接口暴露为控制面受损参数之一。
5. 控制面失效场景下仍沿用统一的显著性分析框架（配对重采样 + sign-flip）。

## Smoke 验证

```bash
python3 scripts_flow/control_plane_impaired_eval.py \
  --algos v1,v2 \
  --topos ba \
  --sizes 20 \
  --seeds 1 \
  --steps 120 \
  --broadcast-losses 0,0.05 \
  --broadcast-delays 0,2 \
  --min-broadcast-periods 1,3 \
  --route-ttls 20,40 \
  --out-prefix run_dir/issue16/issue16_smoke
```

## 输出

- `run_dir/issue16/issue16_smoke_cp_impaired_runs.csv`
- `run_dir/issue16/issue16_smoke_cp_impaired_summary.csv`
- `run_dir/issue16/issue16_smoke_cp_impaired_significance.csv`
- `run_dir/issue16/issue16_smoke_cp_boundary.csv`

## 结论说明

- 本次 PR 为 Smoke 阶段：验证流程与脚本链路可运行，参数维度可控，输出完整。
- 全量矩阵跑完后，再补充最终方法级结论（尤其关于 v1/v2 的可解释退化和对比边界）。
